### PR TITLE
Run CI against java 8 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: java
+
 addons:
+  apt:
+    packages:
+      - libxml2-utils
   chrome: stable
   sauce_connect: true
+
 jdk:
 - oraclejdk8
+- openjdk11
+
+# skip the Travis-CI install phase because Maven handles that directly
 install:
 - "true"
+
 script:
 - "google-chrome --version"
 - "./mvnw -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pokta-tck install"

--- a/custom-login/pom.xml
+++ b/custom-login/pom.xml
@@ -86,13 +86,13 @@
         <dependency>
             <groupId>com.okta.oidc.tck</groupId>
             <artifactId>okta-oidc-tck</artifactId>
-            <version>0.5.0</version>
+            <version>0.5.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>2.5.2</version>
+            <version>2.5.6</version>
             <scope>test</scope>
         </dependency>
 
@@ -126,7 +126,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.20.1</version>
+                        <version>2.22.1</version>
                         <configuration>
                             <dependenciesToScan>
                                 <dependency>com.okta.oidc.tck:okta-oidc-tck</dependency>
@@ -139,7 +139,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
-                        <version>3.0.2</version>
+                        <version>3.1.1</version>
                         <executions>
                             <execution>
                              <id>unpack</id>
@@ -176,7 +176,7 @@
                         <!-- use the frontend plugin to drive javascript based selenium tests -->
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>1.4</version>
+                        <version>1.7.5</version>
                         <configuration>
                             <nodeVersion>${node.version}</nodeVersion>
                             <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>

--- a/okta-hosted-login/pom.xml
+++ b/okta-hosted-login/pom.xml
@@ -91,13 +91,13 @@
                 <dependency>
                     <groupId>com.okta.oidc.tck</groupId>
                     <artifactId>okta-oidc-tck</artifactId>
-                    <version>0.5.0</version>
+                    <version>0.5.1</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.codehaus.groovy</groupId>
                     <artifactId>groovy</artifactId>
-                    <version>2.5.2</version>
+                    <version>2.5.6</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -108,7 +108,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.20.1</version>
+                        <version>2.22.1</version>
                         <configuration>
                             <dependenciesToScan>
                                 <dependency>com.okta.oidc.tck:okta-oidc-tck</dependency>
@@ -121,7 +121,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
-                        <version>3.0.2</version>
+                        <version>3.1.1</version>
                         <executions>
                             <execution>
                              <id>unpack</id>
@@ -158,7 +158,7 @@
                         <!-- use the frontend plugin to drive javascript based selenium tests -->
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>1.4</version>
+                        <version>1.7.5</version>
                         <configuration>
                             <nodeVersion>${node.version}</nodeVersion>
                             <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>

--- a/resource-server/pom.xml
+++ b/resource-server/pom.xml
@@ -57,13 +57,13 @@
         <dependency>
             <groupId>com.okta.oidc.tck</groupId>
             <artifactId>okta-oidc-tck</artifactId>
-            <version>0.5.0</version>
+            <version>0.5.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>2.5.2</version>
+            <version>2.5.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -107,7 +107,7 @@
               <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>2.22.1</version>
                 <configuration>
                     <dependenciesToScan>
                         <dependency>com.okta.oidc.tck:okta-oidc-tck</dependency>


### PR DESCRIPTION
- version bumps in plugins and test libs to support JDK 11 testing
- minor formatting changes to make travis.yml look similar to our other java projects

Fixes: #39