### PR TITLE
Use openjdk8 instead of oraclejdk8 for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ addons:
   sauce_connect: true
 
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
+
+before_install:
+- ./mvnw --version
 
 # skip the Travis-CI install phase because Maven handles that directly
 install:


### PR DESCRIPTION
Also added `mvn --version` to log the JDK version being used