### PR TITLE
Update to Springboot v2.3.3.RELEASE & Support both Opaque token & JWT validation

### DIFF
--- a/custom-login/pom.xml
+++ b/custom-login/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-boot-starter</artifactId>
-            <version>1.4.0</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/custom-login/pom.xml
+++ b/custom-login/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>8.20</version>
+        </dependency>
 
         <!-- Logging -->
         <dependency>
@@ -86,7 +91,7 @@
         <dependency>
             <groupId>com.okta.oidc.tck</groupId>
             <artifactId>okta-oidc-tck</artifactId>
-            <version>0.5.5</version>
+            <version>0.5.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/okta-hosted-login/pom.xml
+++ b/okta-hosted-login/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-boot-starter</artifactId>
-            <version>1.4.0</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/okta-hosted-login/pom.xml
+++ b/okta-hosted-login/pom.xml
@@ -91,7 +91,7 @@
                 <dependency>
                     <groupId>com.okta.oidc.tck</groupId>
                     <artifactId>okta-oidc-tck</artifactId>
-                    <version>0.5.5</version>
+                    <version>0.5.6</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>

--- a/resource-server/README.md
+++ b/resource-server/README.md
@@ -33,8 +33,7 @@ If you want to validate/introspect an opaque token instead, start the resource s
 mvn \
   -Dokta.oauth2.issuer=https://{yourOktaDomain}/oauth2/default \
   -Dokta.oauth2.opaque=true \
-  -Dokta.oauth2.client-id={clientId} \
-  -Dokta.oauth2.client-secret={clientSecret}
+  -Dokta.oauth2.client-id={clientId}
 ```
 
 **front-end:**

--- a/resource-server/README.md
+++ b/resource-server/README.md
@@ -33,7 +33,8 @@ If you want to validate/introspect an opaque token instead, start the resource s
 mvn \
   -Dokta.oauth2.issuer=https://{yourOktaDomain}/oauth2/default \
   -Dokta.oauth2.opaque=true \
-  -Dokta.oauth2.client-id={clientId}
+  -Dokta.oauth2.client-id={clientId} \
+  -Dokta.oauth2.client-secret={clientSecret}
 ```
 
 **front-end:**

--- a/resource-server/README.md
+++ b/resource-server/README.md
@@ -26,6 +26,17 @@ mvn -Dokta.oauth2.issuer=https://{yourOktaDomain}/oauth2/default
 ```
 > **NOTE:** The above command starts the resource server on port 8000. You can browse to `http://localhost:8000` to ensure it has started. If you get the message "401 Unauthorized", it indicates that the resource server is up. You will need to pass an access token to access the resource, which will be done by the front-end below.
 
+By default, the access token JWT returned by your authorization server will be validated by the resource server.
+If you want to validate/introspect an opaque token instead, start the resource server with few additional properties:
+
+```bash
+mvn \
+  -Dokta.oauth2.issuer=https://{yourOktaDomain}/oauth2/default \
+  -Dokta.oauth2.opaque=true \
+  -Dokta.oauth2.client-id={clientId} \
+  -Dokta.oauth2.client-secret={clientSecret}
+```
+
 **front-end:**
 
 Instead of using one of our front-end sample applications listed above, you can also use the [front-end](../front-end) within this repo to quickly test the resource server.

--- a/resource-server/pom.xml
+++ b/resource-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.5.RELEASE</version>
+        <version>2.3.3.RELEASE</version>
     </parent>
 
     <groupId>com.example.okta</groupId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-boot-starter</artifactId>
-            <version>1.4.0</version>
+            <version>1.4.1-SNAPSHOT</version>
         </dependency>
 
         <!-- Other standard Spring starters -->

--- a/resource-server/pom.xml
+++ b/resource-server/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-boot-starter</artifactId>
-            <version>1.4.1-SNAPSHOT</version>
+            <version>2.0.0</version>
         </dependency>
 
         <!-- Other standard Spring starters -->

--- a/resource-server/src/main/java/com/okta/spring/example/ResourceServerExampleApplication.java
+++ b/resource-server/src/main/java/com/okta/spring/example/ResourceServerExampleApplication.java
@@ -8,7 +8,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,9 +32,7 @@ public class ResourceServerExampleApplication {
         @Override
         protected void configure(HttpSecurity http) throws Exception {
             http.authorizeRequests()
-                .anyRequest().authenticated()
-            .and()
-                .oauth2ResourceServer().jwt();
+                .anyRequest().authenticated();
 
             // process CORS annotations
             http.cors();
@@ -50,7 +48,7 @@ public class ResourceServerExampleApplication {
 
         @GetMapping("/api/userProfile")
         @PreAuthorize("hasAuthority('SCOPE_profile')")
-        public Map<String, Object> getUserDetails(JwtAuthenticationToken authentication) {
+        public Map<String, Object> getUserDetails(AbstractOAuth2TokenAuthenticationToken authentication) {
             return authentication.getTokenAttributes();
         }
 

--- a/resource-server/src/main/resources/application.yml
+++ b/resource-server/src/main/resources/application.yml
@@ -2,6 +2,18 @@ server:
   port: 8000
 
 spring:
+#  security:
+#    oauth2:
+#      resourceserver:
+#        opaquetoken:
+#          introspection-uri: https://dev-298876.okta.com/oauth2/default/v1/introspect
+#          client-id: 0oanb5cp8bQwGReSl4x6
+#          client-secret: HgA5I3Mf0dJPJudnqoK4mQTOmIJlIzQXapnUxq8D
+#      client:
+#        provider:
+#          okta:
+#            authorization-uri: http://dev-298876.okta.com/oauth2/default/v1/authorize
+#            token-uri: http://dev-298876.okta.com/oauth2/default/v1/token
   jackson:
     serialization:
       write-dates-as-timestamps: false

--- a/resource-server/src/main/resources/application.yml
+++ b/resource-server/src/main/resources/application.yml
@@ -2,18 +2,6 @@ server:
   port: 8000
 
 spring:
-#  security:
-#    oauth2:
-#      resourceserver:
-#        opaquetoken:
-#          introspection-uri: https://dev-298876.okta.com/oauth2/default/v1/introspect
-#          client-id: 0oanb5cp8bQwGReSl4x6
-#          client-secret: HgA5I3Mf0dJPJudnqoK4mQTOmIJlIzQXapnUxq8D
-#      client:
-#        provider:
-#          okta:
-#            authorization-uri: http://dev-298876.okta.com/oauth2/default/v1/authorize
-#            token-uri: http://dev-298876.okta.com/oauth2/default/v1/token
   jackson:
     serialization:
       write-dates-as-timestamps: false


### PR DESCRIPTION
### What is done?

- Update project to use Spring Boot `v2.3.3.RELEASE`. 
- Update resource server sub module's sample controller - we should now be able to specify JWT or Opaque token validation at resource server startup with `-Dokta.oauth2.opaque=true`; the absence of this property will trigger JWT validation (default). See [here](https://github.com/okta/okta-spring-boot/pull/185) for changes done to `okta-spring-boot-starter` project.