### PR TITLE
Adds support for dynamic chromedriver update

### DIFF
--- a/custom-login/src/test/resources/package.json
+++ b/custom-login/src/test/resources/package.json
@@ -2,12 +2,13 @@
     "name": "@okta/samples-java-spring-custom-login-tests",
     "version": "0.0.2",
     "scripts": {
-        "pretest": "webdriver-manager update --gecko false",
+        "pretest": "node update-se-drivers.js",
         "test:protractor": "protractor e2e-tests/custom-login/conf.js",
         "test": "npm run test:protractor",
         "custom-login-server": "mvn -f ../../pom.xml"
     },
     "devDependencies": {
+       "axios": "^0.20.0",
        "dotenv": "^5.0.1",
        "find-process": "^1.1.0",
        "forever-monitor": "^2.0.0",

--- a/custom-login/src/test/resources/update-se-drivers.js
+++ b/custom-login/src/test/resources/update-se-drivers.js
@@ -1,0 +1,41 @@
+const axios = require('axios');
+const { execSync } = require('child_process');
+
+function getOS() {
+  let os = process.platform;
+  if (os === 'darwin') {
+    os = 'MacOS';
+  } else if (os === 'win32' || os === 'win64') {
+    os = 'Windows';
+  } else if (os === 'linux') {
+    os = 'Linux';
+  }
+  return os;
+}
+
+const os = getOS();
+console.log(`Operating System - ${os}`);
+
+let chromeVersion;
+if (os === 'MacOS') {
+  const chromeVersionString = execSync('/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --version').toString();
+  // Get the major and minor version of the chrome version using regex (1 or more digits followed by a dot followed by 1 or more digits)
+  const matchIndex = 0;
+  chromeVersion = chromeVersionString.match(/(\d+(\.\d+)?)/)[matchIndex];
+} else {
+  chromeVersion = execSync('google-chrome --product-version').toString();
+}
+
+const chromeMajorVersion = chromeVersion.split('.')[0];
+console.log(`Chrome Major Version - ${chromeMajorVersion}`);
+
+const chromeDriverUrl = `https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${chromeMajorVersion}`;
+
+axios.get(chromeDriverUrl).then((response) => {
+  const chromeDriverVersion = response.data;
+  console.log(`Chrome Driver Version - ${chromeDriverVersion}`);
+
+  execSync(`webdriver-manager update --versions.chrome ${chromeDriverVersion} --gecko false --versions.standalone latest`);
+}).catch((err) => {
+  console.log(err);
+});

--- a/okta-hosted-login/src/test/resources/package.json
+++ b/okta-hosted-login/src/test/resources/package.json
@@ -2,12 +2,13 @@
     "name": "@okta/samples-java-spring-hosted-login-tests",
     "version": "0.0.2",
     "scripts": {
-        "pretest": "webdriver-manager update --gecko false",
+        "pretest": "node update-se-drivers.js",
         "test:protractor": "protractor e2e-tests/okta-hosted-login/conf.js",
         "test": "npm run test:protractor",
         "okta-hosted-login-server": "mvn -f ../../pom.xml -Dokta.oauth2.localTokenValidation=false"
     },
     "devDependencies": {
+        "axios": "^0.20.0",
         "dotenv": "^5.0.1",
         "find-process": "^1.1.0",
         "forever-monitor": "^2.0.0",

--- a/okta-hosted-login/src/test/resources/update-se-drivers.js
+++ b/okta-hosted-login/src/test/resources/update-se-drivers.js
@@ -1,0 +1,41 @@
+const axios = require('axios');
+const { execSync } = require('child_process');
+
+function getOS() {
+  let os = process.platform;
+  if (os === 'darwin') {
+    os = 'MacOS';
+  } else if (os === 'win32' || os === 'win64') {
+    os = 'Windows';
+  } else if (os === 'linux') {
+    os = 'Linux';
+  }
+  return os;
+}
+
+const os = getOS();
+console.log(`Operating System - ${os}`);
+
+let chromeVersion;
+if (os === 'MacOS') {
+  const chromeVersionString = execSync('/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --version').toString();
+  // Get the major and minor version of the chrome version using regex (1 or more digits followed by a dot followed by 1 or more digits)
+  const matchIndex = 0;
+  chromeVersion = chromeVersionString.match(/(\d+(\.\d+)?)/)[matchIndex];
+} else {
+  chromeVersion = execSync('google-chrome --product-version').toString();
+}
+
+const chromeMajorVersion = chromeVersion.split('.')[0];
+console.log(`Chrome Major Version - ${chromeMajorVersion}`);
+
+const chromeDriverUrl = `https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${chromeMajorVersion}`;
+
+axios.get(chromeDriverUrl).then((response) => {
+  const chromeDriverVersion = response.data;
+  console.log(`Chrome Driver Version - ${chromeDriverVersion}`);
+
+  execSync(`webdriver-manager update --versions.chrome ${chromeDriverVersion} --gecko false --versions.standalone latest`);
+}).catch((err) => {
+  console.log(err);
+});


### PR DESCRIPTION
- Current `webdriver-manager update` command only works with latest chrome driver
- Running this script will detect the chrome version on machine and use a compatible chrome driver version