### PR TITLE
Updates README to add redirect URI information

### DIFF
--- a/custom-login/README.md
+++ b/custom-login/README.md
@@ -11,6 +11,13 @@ Before running this sample, you will need the following:
 * An Okta Application, configured for Web mode. This is done from the Okta Developer Console and you can find instructions [here][OIDC Web Application Setup Instructions].  When following the wizard, use the default properties.  They are designed to work with our sample applications.
 * Your Okta Application entry needs a login redirect URI. Go to "Login redirect URIs" under "General Settings" for your application, click "Edit" and add http://localhost:8080/authorization-code/callback.
 * Your Okta Application entry needs the logout callback. "Logout redirect URIs" under "General" for the application should list http://localhost:8080. If it is not present, click "Edit" and add it.
+* Ensure that your Okta Application is assigned to "Everyone" group or a custom group or a set of users that need to access the application. Navigate to "Assignments" tab for the application, and click "Assign -> Assign to People" or "Assign -> Assign to Groups" to do this.
+* The source code from this repository:
+
+    ```
+    git clone https://github.com/okta/samples-java-spring.git
+    cd samples-java-spring
+    ```
 
 ## Running This Example
 

--- a/custom-login/README.md
+++ b/custom-login/README.md
@@ -9,6 +9,8 @@ Before running this sample, you will need the following:
 
 * An Okta Developer Account, you can sign up for one at https://developer.okta.com/signup/.
 * An Okta Application, configured for Web mode. This is done from the Okta Developer Console and you can find instructions [here][OIDC Web Application Setup Instructions].  When following the wizard, use the default properties.  They are designed to work with our sample applications.
+* Your Okta Application entry needs a login redirect URI. Go to "Login redirect URIs" under "General Settings" for your application, click "Edit" and add http://localhost:8080/authorization-code/callback.
+* Your Okta Application entry needs the logout callback. "Logout redirect URIs" under "General" for the application should list http://localhost:8080. If it is not present, click "Edit" and add it.
 
 ## Running This Example
 

--- a/okta-hosted-login/README.md
+++ b/okta-hosted-login/README.md
@@ -11,6 +11,7 @@ Before running this sample, you will need the following:
 * An Okta Application, configured for Web mode. This is done from the Okta Developer Console and you can find instructions [here][OIDC Web Application Setup Instructions].  When following the wizard, use the default properties.  They are designed to work with our sample applications.
 * Your Okta Application entry needs a login redirect URI. Go to "Login redirect URIs" under "General Settings" for your application, click "Edit" and add http://localhost:8080/authorization-code/callback.
 * Your Okta Application entry needs the logout callback. "Logout redirect URIs" under "General" for the application should list http://localhost:8080. If it is not present, click "Edit" and add it.
+* Ensure that your Okta Application is assigned to "Everyone" group or a custom group or a set of users that need to access the application. Navigate to "Assignments" tab for the application, and click "Assign -> Assign to People" or "Assign -> Assign to Groups" to do this.
 * The source code from this repository:
 
     ```

--- a/okta-hosted-login/README.md
+++ b/okta-hosted-login/README.md
@@ -9,6 +9,8 @@ Before running this sample, you will need the following:
 
 * An Okta Developer Account, you can sign up for one at https://developer.okta.com/signup/.
 * An Okta Application, configured for Web mode. This is done from the Okta Developer Console and you can find instructions [here][OIDC Web Application Setup Instructions].  When following the wizard, use the default properties.  They are designed to work with our sample applications.
+* Your Okta Application entry needs a login redirect URI. Go to "Login redirect URIs" under "General Settings" for your application, click "Edit" and add http://localhost:8080/authorization-code/callback.
+* Your Okta Application entry needs the logout callback. "Logout redirect URIs" under "General" for the application should list http://localhost:8080. If it is not present, click "Edit" and add it.
 * The source code from this repository:
 
     ```
@@ -32,7 +34,8 @@ Plug these values into the `mvn` commands used to start the application.
 cd okta-hosted-login
 mvn -Dokta.oauth2.issuer=https://{yourOktaDomain}/oauth2/default \
     -Dokta.oauth2.clientId={clientId} \
-    -Dokta.oauth2.clientSecret={clientSecret}
+    -Dokta.oauth2.clientSecret={clientSecret} \
+    -Dokta.oauth2.postLogoutRedirectUri={absoluteLogoutRedirectUri} # (optional) configure this property to enable SSO logout.
 ```
 
 > **NOTE:** Putting secrets on the command line should ONLY be done for examples, do NOT do this in production. Instead, we recommend you store them as environment variables. For example:
@@ -41,6 +44,7 @@ mvn -Dokta.oauth2.issuer=https://{yourOktaDomain}/oauth2/default \
 export OKTA_OAUTH2_ISSUER=https://{yourOktaDomain}/oauth2/default
 export OKTA_OAUTH2_CLIENT_ID={clientId}
 export OKTA_OAUTH2_CLIENT_SECRET={clientSecret}
+export OKTA_OAUTH2_POST_LOGOUT_REDIRECT_URI={absoluteLogoutRedirectUri}
 ```
 
 Now navigate to http://localhost:8080 in your browser.


### PR DESCRIPTION
- Java sample relied on the now deprecated dev console adding the default http://localhost:8080/authorization-code/callback redirect URI to the web app. Now that we don’t have dev console, users need to add this manually. We need to update the sample README and d.o.c guide as well.
- SSO logout doesn't work unless you add -Dokta.oauth2.postLogoutRedirectUri=http://localhost:8080  to your mvn command. This can lead to user confusion about SSO logout. 