### PR TITLE
Run samples with Spring Boot 2.5.1 and Okta Spring Boot Starter 2.1

### DIFF
--- a/custom-login/pom.xml
+++ b/custom-login/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.1</version>
     </parent>
 
     <groupId>com.example.okta</groupId>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-boot-starter</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>com.okta.oidc.tck</groupId>
             <artifactId>okta-oidc-tck</artifactId>
-            <version>0.5.6</version>
+            <version>0.5.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/front-end/pom.xml
+++ b/front-end/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.4.RELEASE</version>
+        <version>2.5.1</version>
     </parent>
 
     <groupId>com.example.okta</groupId>

--- a/okta-hosted-login/pom.xml
+++ b/okta-hosted-login/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.1</version>
     </parent>
 
     <groupId>com.example.okta</groupId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-boot-starter</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -87,7 +87,7 @@
                 <dependency>
                     <groupId>com.okta.oidc.tck</groupId>
                     <artifactId>okta-oidc-tck</artifactId>
-                    <version>0.5.5</version>
+                    <version>0.5.7</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>

--- a/resource-server/pom.xml
+++ b/resource-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.1</version>
     </parent>
 
     <groupId>com.example.okta</groupId>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.okta.spring</groupId>
             <artifactId>okta-spring-boot-starter</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Other standard Spring starters -->
@@ -53,13 +53,19 @@
         <dependency>
             <groupId>com.okta.oidc.tck</groupId>
             <artifactId>okta-oidc-tck</artifactId>
-            <version>0.5.1</version>
+            <version>0.5.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>2.5.14</version>
+            <version>2.5.8</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>3.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
NOTE: build will fail until 2.1 is released (and `-SNAPSHOT` is removed)