### PR TITLE
OKTA-899198 - bumping up spring-security-crypto to 6.4.4

### DIFF
--- a/custom-login/pom.xml
+++ b/custom-login/pom.xml
@@ -53,6 +53,11 @@
             <version>3.4.3</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>6.4.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.thymeleaf.extras</groupId>
             <artifactId>thymeleaf-extras-springsecurity6</artifactId>
             <version>3.1.3.RELEASE</version>


### PR DESCRIPTION
Outdated Library - okta/samples-java-spring@master - org.springframework.security:spring-security-crypto@6.4.3 
https://oktainc.atlassian.net/browse/OKTA-899198