### PR TITLE
Upgrading org.springframework.security to v6.4.6

### DIFF
--- a/custom-login/pom.xml
+++ b/custom-login/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
-            <version>6.4.4</version>
+            <version>6.4.6</version>
         </dependency>
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>

--- a/okta-hosted-login/pom.xml
+++ b/okta-hosted-login/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
-            <version>6.4.4</version>
+            <version>6.4.6</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/resource-server/pom.xml
+++ b/resource-server/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
-            <version>6.4.4</version>
+            <version>6.4.6</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR updates the org.springframework.security dependency from version 6.4.4 to 6.4.6 to remediate multiple vulnerabilities identified by Snyk.