### PR TITLE
Bumping tomcat-embed-core to 11.0.6

### DIFF
--- a/custom-login/pom.xml
+++ b/custom-login/pom.xml
@@ -48,6 +48,11 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>11.0.6</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
             <version>3.5.0</version>

--- a/okta-hosted-login/pom.xml
+++ b/okta-hosted-login/pom.xml
@@ -59,6 +59,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>11.0.6</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>

--- a/resource-server/pom.xml
+++ b/resource-server/pom.xml
@@ -49,6 +49,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>11.0.6</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
             <version>6.5.0</version>


### PR DESCRIPTION
This PR updates the org.springframework.security dependency from version 10.1.39 to 11.0.6 to remediate multiple vulnerabilities identified by Snyk.