### PR TITLE
OKTA-959049 - bumping tomcat-embed-core to 11.0.8

### DIFF
--- a/custom-login/pom.xml
+++ b/custom-login/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>11.0.6</version>
+            <version>11.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/okta-hosted-login/pom.xml
+++ b/okta-hosted-login/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>11.0.6</version>
+            <version>11.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/resource-server/pom.xml
+++ b/resource-server/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>11.0.6</version>
+            <version>11.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
This PR updates the org.springframework.security dependency from version from 11.0.6 to 11.0.8 to remediate multiple vulnerabilities identified by Snyk.