### PR TITLE
fix: upgrade axios from 0.20.0 to 1.15.0 to remediate CVE-2026-40175

### DIFF
--- a/custom-login/src/test/resources/package.json
+++ b/custom-login/src/test/resources/package.json
@@ -8,7 +8,7 @@
         "custom-login-server": "mvn -f ../../pom.xml"
     },
     "devDependencies": {
-       "axios": "^0.20.0",
+       "axios": "^1.15.0",
        "dotenv": "^5.0.1",
        "find-process": "^1.1.0",
        "forever-monitor": "^2.0.0",

--- a/okta-hosted-login/src/test/resources/package.json
+++ b/okta-hosted-login/src/test/resources/package.json
@@ -8,7 +8,7 @@
         "okta-hosted-login-server": "mvn -f ../../pom.xml -Dokta.oauth2.localTokenValidation=false"
     },
     "devDependencies": {
-        "axios": "^0.20.0",
+        "axios": "^1.15.0",
         "dotenv": "^5.0.1",
         "find-process": "^1.1.0",
         "forever-monitor": "^3.0.3",


### PR DESCRIPTION
Resolves OKTA-1156118 - HTTP Response Splitting vulnerability (CRITICAL, CVSS 9.8) in axios@0.20.0. Updated devDependency in both test resource package.json files. No code changes needed as axios.get() API is unchanged.